### PR TITLE
Unicode objects must be encoded before hashing

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def connect_db():
 # Create password hashes
 def hash_pass(passw):
 	m = hashlib.md5()
-	m.update(passw)
+	m.update(passw.encode('utf-8'))
 	return m.hexdigest()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some of us have been having this problem running main.py and it has been solved via changing line 75 to `m.update(passw.encode('utf-8'))` it might be a OS specific thing